### PR TITLE
Clear Befehl erweitert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ src/main/java/SECRETS.java
 target/classes/utils/SECRETS.class
 src/main/java/utils/SECRETS.java
 target/test-classes/utils/SECRETS.class
+SETTINGS.txt
 *.class
 *.class

--- a/src/main/java/commands/chat/Clear.java
+++ b/src/main/java/commands/chat/Clear.java
@@ -1,17 +1,12 @@
 package commands.chat;
 
 import commands.Command;
-import core.Perms;
-import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageHistory;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
-
-import core.coreCommands;
 import utils.MSGS;
 import utils.STATICS;
 
-import java.awt.*;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -33,7 +28,7 @@ public class Clear implements Command {
         return false;
     }
 
-    public static String HELP = "USAGE: ` ~clear <amount ob messages (>2)> to clear an amount of chat messages`";
+    public static String HELP = "USAGE: ` ~clear <amount ob messages (>2) || all || TIMESTAMP>  to clear an amount of chat messages`";
 
 
     private int getInt(String arg) {

--- a/src/main/java/commands/chat/Clear.java
+++ b/src/main/java/commands/chat/Clear.java
@@ -12,6 +12,9 @@ import utils.MSGS;
 import utils.STATICS;
 
 import java.awt.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -50,8 +53,28 @@ public class Clear implements Command {
         try {
             MessageHistory history = new MessageHistory(event.getTextChannel());
             List<Message> msgs;
+            if (args.length == 1 && args[0].equalsIgnoreCase("all")) {
+                try {
+                    while (true) {
+                        msgs = history.retrievePast(1).complete();
+                        msgs.get(0).delete().queue();
+                    }
+                } catch (Exception ex) {
+                    //Nichts tun
+                }
 
-            if (args.length < 1 || (args.length > 0 ? getInt(args[0]) : 1) == 1 && (args.length > 0 ? getInt(args[0]) : 1) < 2) {
+                Message answer = event.getTextChannel().sendMessage(MSGS.success.setDescription(
+                        "Successfully deleted all messages!"
+                ).build()).complete();
+
+                new Timer().schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        answer.delete().queue();
+                    }
+                }, 3000);
+
+            }else if (args.length < 1 || (args.length > 0 ? getInt(args[0]) : 1) == 1 && (args.length > 0 ? getInt(args[0]) : 1) < 2) {
 
                 event.getMessage().delete().queue();
                 msgs = history.retrievePast(2).complete();
@@ -67,6 +90,54 @@ public class Clear implements Command {
                         answer.delete().queue();
                     }
                 }, 3000);
+
+            } else if(args.length == 2) {
+                // 24/03/2013 21:54
+                SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm");
+                StringBuilder builder = new StringBuilder();
+
+                for (String arg: args) {
+                    builder.append(" " + arg);
+                }
+
+                try
+                {
+                    Date date = simpleDateFormat.parse(builder.toString());
+
+                    boolean weiter = true;
+                    try {
+                        while (weiter) {
+                            msgs = history.retrievePast(1).complete();
+                            if (date.before(Date.from(msgs.get(0).getCreationTime().toZonedDateTime().toInstant()))) {
+                                msgs.get(0).delete().queue();
+                            } else {
+                                weiter = false;
+                            }
+
+                        }
+
+                        Message answer = event.getTextChannel().sendMessage(MSGS.success.setDescription(
+                                "Successfully deleted " + args[0] + " messages!"
+                        ).build()).complete();
+
+                        new Timer().schedule(new TimerTask() {
+                            @Override
+                            public void run() {
+                                answer.delete().queue();
+                            }
+                        }, 3000);
+                    } catch (Exception ex) {
+                        //Nichts tun
+                    }
+                }
+                catch (ParseException ex)
+                {
+                    event.getTextChannel().sendMessage(MSGS.error
+                            .addField("Error Type", "Wrong Timeformat.", false)
+                            .addField("Description", "Pleas enter the Time in the right Timeformat:\n" + simpleDateFormat.format(new Date()), false)
+                            .build()
+                    ).queue();
+                }
 
             } else if (getInt(args[0]) <= 100) {
 
@@ -91,6 +162,8 @@ public class Clear implements Command {
                         .build()
                 ).queue();
             }
+
+
         } catch (Exception e) {
             event.getTextChannel().sendMessage(MSGS.error
                     .addField("Error Type", e.getLocalizedMessage(), false)


### PR DESCRIPTION
Hallo,
ich habe den Clear Befehl um 2 Argumente erweitert, es kann entweder also Argument nun noch **all** oder ein Zeitstempel angegeben werden.

**ALL**
Bei dem Argument werden alle Nachichten aus dem Textchannel der Reihe nach gelöscht. Bei einem großen Textchannel kann das eine Weile dauern da immer nur eine Nachicht nach der anderen gelöscht wird

**TIMESTAMP** _08/06/2017 04:05_
Wenn ein Zeitstempel angegeben wird, dann werden alle Nachichten die nach der angegenen Zeit gesendet wurden gelöscht. 

Ich bitte dich aber nochmal alle von mir eingestellten Nachichten zu überprüfen das sich meine English Kenntnisse in Grenzen halten...